### PR TITLE
Set the executable file permissions

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,3 +1,3 @@
 ---
 - name: Install WP-CLI
-  get_url: url={{ phar_url }} dest={{ bin_path }}
+  get_url: url={{ phar_url }} dest={{ bin_path }} mode=0755


### PR DESCRIPTION
The WP-CLI docs recommend adding the executable file permission
