### PR TITLE
Updated the phar_url to the current version

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,2 +1,2 @@
-phar_url: https://github.com/wp-cli/wp-cli/releases/download/v0.18.0/wp-cli-0.18.0.phar
+phar_url: https://raw.githubusercontent.com/wp-cli/builds/gh-pages/phar/wp-cli.phar
 bin_path: /usr/local/bin/wp


### PR DESCRIPTION
Rather than hard coding a specific version, the default should be the most current https://wp-cli.org/
